### PR TITLE
Update ec2-metadata to allow partition discovery

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,20 @@
+name: shellcheck
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get -y install shellcheck
+    - name: Run shellcheck
+      run: shellcheck -s bash -S warning ec2-metadata ec2nvme-nsid ec2udev-vbd

--- a/amazon-ec2-utils.spec
+++ b/amazon-ec2-utils.spec
@@ -1,6 +1,6 @@
 Name:      amazon-ec2-utils
 Summary:   A set of tools for running in EC2
-Version:   2.0.1
+Version:   2.1.0
 Release:   1%{?dist}
 License:   MIT
 Group:     System Tools
@@ -18,7 +18,7 @@ Source26:  53-ec2-read-ahead-kb.rules
 URL:       https://github.com/aws/amazon-ec2-utils
 BuildArch: noarch
 Provides:  ec2-utils = %{version}-%{release}
-Obsoletes: ec2-utils < 2.0
+Obsoletes: ec2-utils < 2.1
 Provides:  ec2-metadata = %{version}-%{release}
 Obsoletes: ec2-metadata <= 0.1
 Requires:  curl
@@ -75,6 +75,10 @@ rm -rf $RPM_BUILD_ROOT
 /etc/udev/rules.d/60-cdrom_id.rules
 
 %changelog
+
+* Thu Apr  6 2023 Noah Meyerhans <nmeyerha@amazon.com> - 2.1.0-1
+- Add --quiet option to ec2-metadata
+- Add --partition support to ec2-metadata
 
 * Fri Feb 11 2022 Noah Meyerhans <nmeyerha@amazon.com> 2.0.1-1
 - Don't lose NVME symlinks on udev change events

--- a/doc/ec2-metadata.8
+++ b/doc/ec2-metadata.8
@@ -50,9 +50,11 @@ will print all known metadata fields by default.  The following
 options can be used to restrict the output to the selected fields.
 
 .TP
-.B \-\-all                     Show all metadata information for this host (also default).
+.B \-\-all
+Show all metadata information for this host (also default).
 .TP
-.B \-a/\-\-ami-id               The AMI ID used to launch this instance
+.B \-a/\-\-ami-id
+The AMI ID used to launch this instance
 .TP
 .B \-l/\-\-ami-launch-index
 The index of this instance in the reservation (per AMI).
@@ -108,6 +110,12 @@ Names of the security groups the instance is launched in. Only available if supp
 .B \-d/\-\-user-data
 User-supplied data.Only available if supplied at instance launch time.
 .TP
+.B \-t/\-\-tags
+Print EC2 resource tags if permitted in EC2 Instance Metadata Options.
+.TP
+.B \-\-quiet
+Don't print metadata keys
+.TP
 .B \-h, \-\-help
 Show summary of options.
 .SH SEE ALSO
@@ -121,5 +129,10 @@ https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
 EC2 Instance Metadata Query Tool
 .RS 4
 https://aws.amazon.com/code/ec2-instance-metadata-query-tool/
+.RE
+.IP " 3." 4
+Work with instance tags in instance metadata
+.RS 4
+https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS
 .RE
 

--- a/ec2-metadata
+++ b/ec2-metadata
@@ -158,59 +158,73 @@ if [ "$#" -eq 0 ]; then
 	print_all
 fi
 
+declare -a actions
+shortopts=almnbithokzPcpvuresdg
+longopts=(ami-id ami-launch-index ami-manifest-path ancestor-ami-ids block-device-mapping
+          instance-id instance-type local-hostname local-ipv4 kernel-id availability-zone
+          partition product-codes public-hostname public-ipv4 public-keys ramdisk-id
+          reservation-id security-groups user-data tags help all)
+
+oldIFS="$IFS"
+IFS=,
+TEMP=$(getopt -o $shortopts --longoptions "${longopts[*]}" -n 'ec2-metadata' -- "$@")
+if [ $? -ne 0 ]; then
+    echo 'Terminating...' >&2
+    exit 1
+fi
+IFS="$oldIFS"
+
+eval set -- "$TEMP"
+unset TEMP
+
+while true; do
+    case "$1" in
+        --help)
+            print_help ; shift
+            exit 0
+            ;;
+        --)
+            shift ; break
+            ;;
+        --?*|-?)
+            # pass most arguments to the original action processing
+            # code after setting options
+            actions+=("$1"); shift
+            ;;
+        *)
+            echo 'Unknown error: ' "[$1]" >&2
+            exit 1
+            ;;
+    esac
+done
+
 #start processing command line arguments
-while [ "$1" != "" ]; do
-	case $1 in
-	-a | --ami-id )                print_normal_metric ami-id meta-data/ami-id
-																 ;;
-	-l | --ami-launch-index )      print_normal_metric ami-launch-index meta-data/ami-launch-index
-																 ;;
-	-m | --ami-manifest-path )     print_normal_metric ami-manifest-path meta-data/ami-manifest-path
-																 ;;
-	-n | --ancestor-ami-ids )      print_normal_metric ancestor-ami-ids meta-data/ancestor-ami-ids
-																 ;;
-	-b | --block-device-mapping )  print_block-device-mapping
-																 ;;
-	-i | --instance-id )           print_normal_metric instance-id meta-data/instance-id
-																 ;;
-	-t | --instance-type )         print_normal_metric instance-type meta-data/instance-type
-																 ;;
-	-h | --local-hostname )        print_normal_metric local-hostname meta-data/local-hostname
-																 ;;
-	-o | --local-ipv4 )            print_normal_metric local-ipv4 meta-data/local-ipv4
-																 ;;
-	-k | --kernel-id )             print_normal_metric kernel-id meta-data/kernel-id
-																 ;;
-	-z | --availability-zone )     print_normal_metric placement meta-data/placement/availability-zone
-																 ;;
-	-P | --partition )             print_normal_metric partition meta-data/services/partition
-																 ;;
-	-c | --product-codes )         print_normal_metric product-codes meta-data/product-codes
-																 ;;
-	-p | --public-hostname )       print_normal_metric public-hostname meta-data/public-hostname
-																 ;;
-	-v | --public-ipv4 )           print_normal_metric public-ipv4 meta-data/public-ipv4
-																 ;;
-	-u | --public-keys )           print_public-keys
-																 ;;
-	-r | --ramdisk-id )            print_normal_metric ramdisk-id /meta-data/ramdisk-id
-																 ;;
-	-e | --reservation-id )        print_normal_metric reservation-id /meta-data/reservation-id
-																 ;;
-	-s | --security-groups )       print_normal_metric security-groups meta-data/security-groups
-																 ;;
-	-d | --user-data )             print_normal_metric user-data user-data
-																 ;;
-	-g | --tags )                  print_tags
-																 ;;
-	     --help )                  print_help
-								 exit
-																 ;;
-	--all )                        print_all
-								 exit 
-																 ;;
-	* )                            print_help
-								 exit 1
+for action in "${actions[@]}"; do
+	case "$action" in
+	    -a | --ami-id )                print_normal_metric ami-id meta-data/ami-id ;;
+	    -l | --ami-launch-index )      print_normal_metric ami-launch-index meta-data/ami-launch-index ;;
+	    -m | --ami-manifest-path )     print_normal_metric ami-manifest-path meta-data/ami-manifest-path ;;
+	    -n | --ancestor-ami-ids )      print_normal_metric ancestor-ami-ids meta-data/ancestor-ami-ids ;;
+	    -b | --block-device-mapping )  print_block-device-mapping ;;
+	    -i | --instance-id )           print_normal_metric instance-id meta-data/instance-id ;;
+	    -t | --instance-type )         print_normal_metric instance-type meta-data/instance-type ;;
+	    -h | --local-hostname )        print_normal_metric local-hostname meta-data/local-hostname ;;
+	    -o | --local-ipv4 )            print_normal_metric local-ipv4 meta-data/local-ipv4 ;;
+	    -k | --kernel-id )             print_normal_metric kernel-id meta-data/kernel-id ;;
+	    -z | --availability-zone )     print_normal_metric placement meta-data/placement/availability-zone ;;
+	    -P | --partition )             print_normal_metric partition meta-data/services/partition ;;
+	    -c | --product-codes )         print_normal_metric product-codes meta-data/product-codes ;;
+	    -p | --public-hostname )       print_normal_metric public-hostname meta-data/public-hostname ;;
+	    -v | --public-ipv4 )           print_normal_metric public-ipv4 meta-data/public-ipv4 ;;
+	    -u | --public-keys )           print_public-keys ;;
+	    -r | --ramdisk-id )            print_normal_metric ramdisk-id /meta-data/ramdisk-id ;;
+	    -e | --reservation-id )        print_normal_metric reservation-id /meta-data/reservation-id ;;
+	    -s | --security-groups )       print_normal_metric security-groups meta-data/security-groups ;;
+	    -d | --user-data )             print_normal_metric user-data user-data ;;
+	    -g | --tags )                  print_tags ;;
+	    --all )                        print_all; exit ;;
 	esac
 	shift
 done
+
+exit 0

--- a/ec2-metadata
+++ b/ec2-metadata
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #

--- a/ec2-metadata
+++ b/ec2-metadata
@@ -44,6 +44,7 @@ Options:
 
 METADATA_BASEURL="http://169.254.169.254"
 METADATA_TOKEN_PATH="latest/api/token"
+QUIET=""
 
 function set_imds_token()
 {
@@ -67,7 +68,7 @@ function get_meta()
 #print standard metric
 function print_normal_metric() {
 	metric_path=$2
-	echo -n $1": "
+    [ -z "$QUIET" ] && echo -n $1": "
 	RESPONSE=$(get_meta ${metric_path})
 	if [ -n "${RESPONSE}" ]; then
 		echo "$RESPONSE"
@@ -79,11 +80,12 @@ function print_normal_metric() {
 #print block-device-mapping
 function print_block-device-mapping()
 {
-	echo 'block-device-mapping: '
+	[ -z "$QUIET" ] && echo 'block-device-mapping: '
 	x=$(get_meta meta-data/block-device-mapping/)
 	if [ -n "${x}" ]; then
 		for i in $x; do
-		    echo -e '\t' $i: "$(get_meta meta-data/block-device-mapping/$i)"
+            [ -z "$QUIET" ] && echo -ne '\t' "$i: "
+            echo "$(get_meta meta-data/block-device-mapping/$i)"
 		done
 	else
 		echo not available
@@ -93,17 +95,17 @@ function print_block-device-mapping()
 #print public-keys
 function print_public-keys()
 {
-	echo 'public-keys: '
+	[ -z "$QUIET" ] && echo 'public-keys: '
 	x=$(get_meta meta-data/public-keys/)
 	if [ -n "${x}" ]; then
 		for i in $x; do
 			index=$(echo $i|cut -d = -f 1)
 			keyname=$(echo $i|cut -d = -f 2)
-			echo keyname:$keyname
-			echo index:$index
+			[ -z "$QUIET" ] && echo keyname:$keyname
+			[ -z "$QUIET" ] && echo index:$index
 			format=$(get_meta meta-data/public-keys/$index/)
-			echo format:$format
-			echo 'key:(begins from next line)'
+			[ -z "$QUIET" ] && echo format:$format
+			[ -z "$QUIET" ] && echo 'key:(begins from next line)'
 			echo "$(get_meta meta-data/public-keys/$index/$format)"
 		done
 	else
@@ -114,11 +116,12 @@ function print_public-keys()
 #print tags
 function print_tags()
 {
-	echo 'tags: '
+	[ -z "$QUIET" ] && echo 'tags: '
 	x=$(get_meta meta-data/tags/instance/)
 	if [ -n "${x}" ]; then
 		for i in $x; do
-			echo -e '\t' $i: "$(get_meta meta-data/tags/instance/$i)"
+            echo -n -e '\t' "$i: "
+            echo "$(get_meta meta-data/tags/instance/$i)"
 		done
 	else
 		echo not available
@@ -163,7 +166,7 @@ shortopts=almnbithokzPcpvuresdg
 longopts=(ami-id ami-launch-index ami-manifest-path ancestor-ami-ids block-device-mapping
           instance-id instance-type local-hostname local-ipv4 kernel-id availability-zone
           partition product-codes public-hostname public-ipv4 public-keys ramdisk-id
-          reservation-id security-groups user-data tags help all)
+          reservation-id security-groups user-data tags help all quiet)
 
 oldIFS="$IFS"
 IFS=,
@@ -182,6 +185,9 @@ while true; do
         --help)
             print_help ; shift
             exit 0
+            ;;
+        --quiet)
+            QUIET=1 ; shift
             ;;
         --)
             shift ; break

--- a/ec2-metadata
+++ b/ec2-metadata
@@ -30,6 +30,7 @@ Options:
 -o/--local-ipv4           Public IP address if launched with direct addressing; private IP address if launched with public addressing.
 -k/--kernel-id            The ID of the kernel launched with this instance, if applicable.
 -z/--availability-zone    The availability zone in which the instance launched. Same as placement
+-P/--partition            The AWS partition name.
 -c/--product-codes        Product codes associated with this instance.
 -p/--public-hostname      The public hostname of the instance.
 -v/--public-ipv4          NATted public IP Address
@@ -137,6 +138,7 @@ function print_all()
 	print_normal_metric local-ipv4 meta-data/local-ipv4
 	print_normal_metric kernel-id meta-data/kernel-id
 	print_normal_metric placement meta-data/placement/availability-zone
+	print_normal_metric partition meta-data/services/partition
 	print_normal_metric product-codes meta-data/product-codes
 	print_normal_metric public-hostname meta-data/public-hostname
 	print_normal_metric public-ipv4 meta-data/public-ipv4
@@ -180,6 +182,8 @@ while [ "$1" != "" ]; do
 	-k | --kernel-id )             print_normal_metric kernel-id meta-data/kernel-id
 																 ;;
 	-z | --availability-zone )     print_normal_metric placement meta-data/placement/availability-zone
+																 ;;
+	-P | --partition )             print_normal_metric partition meta-data/services/partition
 																 ;;
 	-c | --product-codes )         print_normal_metric product-codes meta-data/product-codes
 																 ;;

--- a/ec2nvme-nsid
+++ b/ec2nvme-nsid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 # Copyright Amazon.com, Inc. and its affiliates. All Rights Reserved.
 #

--- a/ec2udev-vbd
+++ b/ec2udev-vbd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/bash
 
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 #


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

There are several commits in this PR. The functionality changes are:

1. Add `--partition` support to `ec2-metadata`, allowing for easy querying of the AWS [partition](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html) attribute by the instance
2. Add `--quiet` support to `ec2-metadata` to suppress tag keys from the output.

Example:

```
[ec2-user@ip-10-0-0-230 ~]$ ./ec2-metadata --public-ipv4
public-ipv4: 50.112.150.25
[ec2-user@ip-10-0-0-230 ~]$ ./ec2-metadata --public-ipv4 --quiet
50.112.150.25
```
and

```
[ec2-user@ip-10-0-0-230 ~]$ ./ec2-metadata --partition
partition: aws
[ec2-user@ip-10-0-0-230 ~]$ ./ec2-metadata --partition --quiet
aws
```
This PR also configures automatic `shellcheck` execution using GitHub Actions, which replaces the earlier CircleCI integration.  Results for the current branch are [available](https://github.com/nmeyerhans/amazon-ec2-utils/actions/runs/4635674153/jobs/8202922925).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
