### PR TITLE
Add --url flag to ec2-metadata to override metadata-server

### DIFF
--- a/ec2-metadata
+++ b/ec2-metadata
@@ -41,7 +41,8 @@ Options:
 -s/--security-groups      Names of the security groups the instance is launched in. Only available if supplied at instance launch time
 -d/--user-data            User-supplied data.Only available if supplied at instance launch time.
 -g/--tags                 Tags assigned to this instance.
---quiet                   Suppress tag keys from the output."
+--quiet                   Suppress tag keys from the output.
+--url                     Override base URL for metadata server (default http://169.254.169.254)"
 }
 
 METADATA_BASEURL="http://169.254.169.254"
@@ -169,7 +170,7 @@ shortopts=almnbithokzPcpvuresdgR
 longopts=(ami-id ami-launch-index ami-manifest-path ancestor-ami-ids block-device-mapping
           instance-id instance-type local-hostname local-ipv4 kernel-id availability-zone
           partition product-codes public-hostname public-ipv4 public-keys ramdisk-id
-          reservation-id security-groups user-data tags region help all quiet)
+          reservation-id security-groups user-data tags region help all quiet url)
 
 oldIFS="$IFS"
 IFS=,
@@ -191,6 +192,9 @@ while true; do
             ;;
         --quiet)
             QUIET=1 ; shift
+            ;;
+        --url)
+            METADATA_BASEURL=$2; shift; shift
             ;;
         --)
             shift ; break


### PR DESCRIPTION
This is useful for situations where you want to use a mock metadata server, such as https://github.com/aws/amazon-ec2-metadata-mock

This also allows to simulate EC2 environments locally, using https://github.com/retpolanne/cloud-vm-sim for example.

*Issue #, if available:*

*Description of changes:*

Add --url flag to override METADATA_BASEURL so that one can use another metadata server instead of the default one.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
