### PR TITLE
Add --aws-domain option to ec2-metadata to get the top-level service domain

### DIFF
--- a/amazon-ec2-utils.spec
+++ b/amazon-ec2-utils.spec
@@ -1,6 +1,6 @@
 Name:      amazon-ec2-utils
 Summary:   A set of tools for running in EC2
-Version:   2.2.0
+Version:   2.2.1
 Release:   1%{?dist}
 License:   MIT
 Group:     System Tools
@@ -78,6 +78,9 @@ rm -rf $RPM_BUILD_ROOT
 /etc/udev/rules.d/60-cdrom_id.rules
 
 %changelog
+* Tue Dec 17 2024 Keith Gable <gablk@amazon.com> - 2.2.1-1
+- Add support for --aws-domain to ec2-metadata
+
 * Wed May 29 2024 Kuniyuki Iwashima <kuniyu@amazon.com> - 2.2.1
 - Add symlink for ENA PTP device.
 

--- a/ec2-metadata
+++ b/ec2-metadata
@@ -216,7 +216,7 @@ for action in "${actions[@]}"; do
 	    -l | --ami-launch-index )      print_normal_metric ami-launch-index meta-data/ami-launch-index ;;
 	    -m | --ami-manifest-path )     print_normal_metric ami-manifest-path meta-data/ami-manifest-path ;;
 	    -n | --ancestor-ami-ids )      print_normal_metric ancestor-ami-ids meta-data/ancestor-ami-ids ;;
-		-D | --aws-domain )            print_normal_metric aws-domain meta-data/services/domain ;;
+	    -D | --aws-domain )            print_normal_metric aws-domain meta-data/services/domain ;;
 	    -b | --block-device-mapping )  print_block-device-mapping ;;
 	    -i | --instance-id )           print_normal_metric instance-id meta-data/instance-id ;;
 	    -t | --instance-type )         print_normal_metric instance-type meta-data/instance-type ;;

--- a/ec2-metadata
+++ b/ec2-metadata
@@ -8,7 +8,7 @@
 
 function print_help()
 {
-echo "ec2-metadata v0.1.4
+echo "ec2-metadata v0.1.5
 Use to retrieve EC2 instance metadata from within a running EC2 instance. 
 e.g. to retrieve instance id: ec2-metadata -i
 		 to retrieve ami id: ec2-metadata -a
@@ -23,6 +23,7 @@ Options:
 -l/--ami-launch-index     The index of this instance in the reservation (per AMI).
 -m/--ami-manifest-path    The manifest path of the AMI with which the instance was launched.
 -n/--ancestor-ami-ids     The AMI IDs of any instances that were rebundled to create this AMI.
+-D/--aws-domain           The root domain name that AWS uses in this region
 -b/--block-device-mapping Defines native device names to use when exposing virtual devices.
 -i/--instance-id          The ID of this instance
 -t/--instance-type        The type of instance to launch. For more information, see Instance Types.
@@ -136,6 +137,7 @@ function print_all()
 	print_normal_metric ami-launch-index meta-data/ami-launch-index
 	print_normal_metric ami-manifest-path meta-data/ami-manifest-path
 	print_normal_metric ancestor-ami-ids meta-data/ancestor-ami-ids
+	print_normal_metric aws-domain meta-data/services/domain
 	print_block-device-mapping
 	print_normal_metric instance-id meta-data/instance-id
 	print_normal_metric instance-type meta-data/instance-type
@@ -165,8 +167,8 @@ if [ "$#" -eq 0 ]; then
 fi
 
 declare -a actions
-shortopts=almnbithokzPcpvuresdgR
-longopts=(ami-id ami-launch-index ami-manifest-path ancestor-ami-ids block-device-mapping
+shortopts=almnDbithokzPcpvuresdgR
+longopts=(ami-id ami-launch-index ami-manifest-path ancestor-ami-ids aws-domain block-device-mapping
           instance-id instance-type local-hostname local-ipv4 kernel-id availability-zone
           partition product-codes public-hostname public-ipv4 public-keys ramdisk-id
           reservation-id security-groups user-data tags region help all quiet)
@@ -214,6 +216,7 @@ for action in "${actions[@]}"; do
 	    -l | --ami-launch-index )      print_normal_metric ami-launch-index meta-data/ami-launch-index ;;
 	    -m | --ami-manifest-path )     print_normal_metric ami-manifest-path meta-data/ami-manifest-path ;;
 	    -n | --ancestor-ami-ids )      print_normal_metric ancestor-ami-ids meta-data/ancestor-ami-ids ;;
+		-D | --aws-domain )            print_normal_metric aws-domain meta-data/services/domain ;;
 	    -b | --block-device-mapping )  print_block-device-mapping ;;
 	    -i | --instance-id )           print_normal_metric instance-id meta-data/instance-id ;;
 	    -t | --instance-type )         print_normal_metric instance-type meta-data/instance-type ;;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This adds a -D / --aws-domain option to ec2-metadata. This makes it easier to construct e.g. DNF repo URLs that need to be different if the AWS partition uses a different top-level service domain.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.