### PR TITLE
spec: install ebsnvme in sbindir

### DIFF
--- a/amazon-ec2-utils.spec
+++ b/amazon-ec2-utils.spec
@@ -40,16 +40,18 @@ amazon-ec2-utils contains a set of utilities for running in ec2.
 rm -rf $RPM_BUILD_ROOT
 mkdir -p $RPM_BUILD_ROOT%{_bindir}
 mkdir -p $RPM_BUILD_ROOT%{_udevrulesdir}
-mkdir -p $RPM_BUILD_ROOT/%{_sbindir}
+mkdir -p $RPM_BUILD_ROOT%{_sbindir}
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/udev/rules.d/
 mkdir -p $RPM_BUILD_ROOT%{_mandir}/man8/
 
 install -m755 %{SOURCE0} $RPM_BUILD_ROOT%{_bindir}
-install -m755 %{SOURCE1} $RPM_BUILD_ROOT/%{_sbindir}
+install -m755 %{SOURCE1} $RPM_BUILD_ROOT%{_sbindir}
 install -m644 %{SOURCE2} $RPM_BUILD_ROOT%{_udevrulesdir}
+install -m755 %{SOURCE24} $RPM_BUILD_ROOT%{_sbindir}
 install -m644 %{SOURCE25} $RPM_BUILD_ROOT%{_udevrulesdir}
 install -m644 %{SOURCE26} $RPM_BUILD_ROOT%{_udevrulesdir}
 install -m644 %{SOURCE27} $RPM_BUILD_ROOT%{_udevrulesdir}
+install -m755 %{SOURCE28} $RPM_BUILD_ROOT%{_sbindir}
 # Install 60-cdrom_id.rules to /etc rather than %{_udevrulesdir}
 # because it is intended as an override of a systemd-provided rules
 # file:
@@ -58,7 +60,6 @@ install -m644 %{SOURCE16} $RPM_BUILD_ROOT%{_sysconfdir}/udev/rules.d/
 #udev rules for nvme block devices and supporting scripts
 install -m644 %{SOURCE22} $RPM_BUILD_ROOT%{_udevrulesdir}
 install -m755 %{SOURCE23} $RPM_BUILD_ROOT%{_sbindir}/ec2nvme-nsid
-install -m755 %{SOURCE24} $RPM_BUILD_ROOT/%{_sbindir}
 
 %check
 %{python3} -m py_compile %{SOURCE24}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amazonlinux/amazon-ec2-utils/issues/48

*Description of changes:*
this patch fixes the rpmbuild errors because of missing `ebsnvme` install (Fixes https://github.com/amazonlinux/amazon-ec2-utils/issues/48 where the bug was discovered);

before: 
```
$ rpmbuild -bb rpmbuild/SPECS/amazon-ec2-utils.spec
.
.
+ exit 0
Processing files: amazon-ec2-utils-2.2.0-1.amzn2023.noarch
error: File not found: /home/ec2-user/rpmbuild/BUILDROOT/amazon-ec2-utils-2.2.0-1.amzn2023.x86_64/usr/sbin/ebsnvme


RPM build errors:
    File not found: /home/ec2-user/rpmbuild/BUILDROOT/amazon-ec2-utils-2.2.0-1.amzn2023.x86_64/usr/sbin/ebsnvme
```
after:
```
$ rpmbuild -bb rpmbuild/SPECS/amazon-ec2-utils.spec
.
.
+ install -m755 /home/ec2-user/rpmbuild/SOURCES/ebsnvme /home/ec2-user/rpmbuild/BUILDROOT/amazon-ec2-utils-2.2.0-1.amzn2023.x86_64/usr/sbin
.
.
.
+ rm -rf /home/ec2-user/rpmbuild/BUILDROOT/amazon-ec2-utils-2.2.0-1.amzn2023.x86_64
+ RPM_EC=0
++ jobs -p
+ exit 0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
